### PR TITLE
Calculate total in parallel mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Calculate total in parallel mode
 
 ## [0.3.0] - 2021-02-24
 ### Added

--- a/lib/print.js
+++ b/lib/print.js
@@ -37,12 +37,13 @@ function errors (tests) {
   Base.list(tests);
 }
 
-function status (total, stats) {
+function status (total, stats, isParallelMode) {
   const rows = [
-    ["Total", total, "±"],
+    ...(isParallelMode ? [] : [["Total", total, "±"]]),
     ["Passing", stats.passes, Base.color("bright pass", "✓")],
     ["Failing", stats.failures, Base.color("bright fail", "✗")],
   ];
+
   if (stats.pending)
     rows.push(["Pending", stats.pending, Base.color("pending", "∗")]);
   if (stats.duration)

--- a/lib/print.js
+++ b/lib/print.js
@@ -37,12 +37,17 @@ function errors (tests) {
   Base.list(tests);
 }
 
-function status (total, stats, isParallelMode) {
-  const rows = [
-    ...(isParallelMode ? [] : [["Total", total, "±"]]),
+function status (total, stats) {
+  const rows = [];
+
+  if (typeof total == "number") {
+    rows.push(["Total", total, "±"]);
+  }
+
+  rows.push(
     ["Passing", stats.passes, Base.color("bright pass", "✓")],
     ["Failing", stats.failures, Base.color("bright fail", "✗")],
-  ];
+  );
 
   if (stats.pending)
     rows.push(["Pending", stats.pending, Base.color("pending", "∗")]);

--- a/lib/print.js
+++ b/lib/print.js
@@ -40,9 +40,8 @@ function errors (tests) {
 function status (total, stats) {
   const rows = [];
 
-  if (typeof total == "number") {
+  if (typeof total === "number")
     rows.push(["Total", total, "±"]);
-  }
 
   rows.push(
     ["Passing", stats.passes, Base.color("bright pass", "✓")],

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -17,8 +17,9 @@ module.exports = isInteractive() ?
 
 function InteractiveReporter (runner, options) {
   Base.call(this, runner, options);
+  const isParallelMode = runner.isParallelMode();
   const stats = this.stats;
-  let statusLineCount = print.status(runner.total, stats);
+  let statusLineCount = print.status(runner.total, stats, isParallelMode);
 
   runner
     .on(EVENT_TEST_PASS, update)
@@ -28,7 +29,7 @@ function InteractiveReporter (runner, options) {
   function update (test, err) {
     print.clear(statusLineCount);
     if (err) print.error(stats.failures, test);
-    statusLineCount = print.status(runner.total, stats);
+    statusLineCount = print.status(runner.total, stats, isParallelMode);
   }
 }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -18,7 +18,8 @@ module.exports = isInteractive() ?
 function InteractiveReporter (runner, options) {
   Base.call(this, runner, options);
   const stats = this.stats;
-  const total = runner.isParallelMode() ? null : runner.total;
+  const isParallelMode = runner.isParallelMode();
+  const total = isParallelMode ? null : runner.total;
   let statusLineCount = print.status(total, stats);
 
   runner
@@ -35,7 +36,8 @@ function InteractiveReporter (runner, options) {
   function end (test, err) {
     print.clear(statusLineCount);
     if (err) print.error(stats.failures, test);
-    statusLineCount = print.status(getTotal(runner, stats), stats);
+    const total = isParallelMode ? calculateTotalFromStats(stats) : runner.total;
+    statusLineCount = print.status(total, stats);
   }
 }
 
@@ -56,10 +58,6 @@ function NonInteractiveReporter (runner, options) {
     print.result(stats);
     print.errors(this.failures);
   });
-}
-
-function getTotal(runner, stats) {
-  return runner.isParallelMode() ? calculateTotalFromStats(stats) : runner.total;
 }
 
 function calculateTotalFromStats(stats) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -37,19 +37,32 @@ function InteractiveReporter (runner, options) {
     if (err) print.error(stats.failures, test);
     statusLineCount = print.status(getTotal(runner, stats), stats);
   }
-
-  function getTotal(runner, stats) {
-    return runner.isParallelMode() ? stats.passes + stats.failures + stats.pending : runner.total;
-  }
 }
 
 function NonInteractiveReporter (runner, options) {
   Base.call(this, runner, options);
   const stats = this.stats;
-  print.total(runner.total);
+  const isParallelMode = runner.isParallelMode();
+
+  if (!isParallelMode) {
+    print.total(runner.total);
+  }
 
   runner.once(EVENT_RUN_END, () => {
+    if (isParallelMode) {
+      print.total(calculateTotalFromStats(stats));
+    }
+
     print.result(stats);
     print.errors(this.failures);
   });
 }
+
+function getTotal(runner, stats) {
+  return runner.isParallelMode() ? calculateTotalFromStats(stats) : runner.total;
+}
+
+function calculateTotalFromStats(stats) {
+  return stats.passes + stats.failures + stats.pending;
+}
+

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -17,19 +17,29 @@ module.exports = isInteractive() ?
 
 function InteractiveReporter (runner, options) {
   Base.call(this, runner, options);
-  const isParallelMode = runner.isParallelMode();
   const stats = this.stats;
-  let statusLineCount = print.status(runner.total, stats, isParallelMode);
+  const total = runner.isParallelMode() ? null : total;
+  let statusLineCount = print.status(total, stats);
 
   runner
     .on(EVENT_TEST_PASS, update)
     .on(EVENT_TEST_FAIL, update)
-    .once(EVENT_RUN_END, update);
+    .once(EVENT_RUN_END, end);
 
   function update (test, err) {
     print.clear(statusLineCount);
     if (err) print.error(stats.failures, test);
-    statusLineCount = print.status(runner.total, stats, isParallelMode);
+    statusLineCount = print.status(total, stats);
+  }
+
+  function end (test, err) {
+    print.clear(statusLineCount);
+    if (err) print.error(stats.failures, test);
+    statusLineCount = print.status(getTotal(runner, stats), stats);
+  }
+
+  function getTotal(runner, stats) {
+    return runner.isParallelMode() ? stats.passes + stats.failures + stats.pending : runner.total;
   }
 }
 
@@ -37,6 +47,7 @@ function NonInteractiveReporter (runner, options) {
   Base.call(this, runner, options);
   const stats = this.stats;
   print.total(runner.total);
+
   runner.once(EVENT_RUN_END, () => {
     print.result(stats);
     print.errors(this.failures);

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -18,7 +18,7 @@ module.exports = isInteractive() ?
 function InteractiveReporter (runner, options) {
   Base.call(this, runner, options);
   const stats = this.stats;
-  const total = runner.isParallelMode() ? null : total;
+  const total = runner.isParallelMode() ? null : runner.total;
   let statusLineCount = print.status(total, stats);
 
   runner


### PR DESCRIPTION
When running mocha in parallel mode the runner does not return the total test count.

This outputs a calculated total at the end if using parallel mode.

- [x] non-tty support